### PR TITLE
FIX: issue with bulk uploading PVs with tags associated

### DIFF
--- a/app/services/tag_service.py
+++ b/app/services/tag_service.py
@@ -121,7 +121,8 @@ class TagService:
         )
         await self.tag_repo.create(tag)
 
-        # Refresh group to get updated tags
+        # Expire cached group and refresh to get updated tags
+        self.group_repo.session.expire(group)
         group = await self.group_repo.get_with_tags(group_id)
 
         return TagGroupDTO(


### PR DESCRIPTION
## Description
SQLAlchemy was returning a cached version of the group that didn't include the new tag, causing an issue with bulk uploading PVs with tags associated with them

## Motivation
Makes it possible to bulk upload pvs with tags 

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code contains descriptive docstrings
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
