### PR TITLE
ENH: Add temporary password to redis server

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -24,7 +24,9 @@ class Settings(BaseSettings):
     epics_chunk_size: int = 1000  # Batch size for progress updates (smaller for better connection handling)
 
     # Redis configuration
-    redis_url: str = "redis://localhost:6379/0"
+    redis_username: str = ""
+    redis_password: str = "squirrel"
+    redis_url: str = f"redis://{redis_username}:{redis_password}@localhost:6379/0"
     redis_pv_cache_ttl: int = 60  # seconds
     redis_pv_hash_key: str = "squirrel:pv:values"
     redis_pv_metadata_key: str = "squirrel:pv:metadata"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,10 +19,11 @@ services:
   redis:
     image: redis:7-alpine
     container_name: squirrel-redis
+    command: redis-server --requirepass squirrel
     ports:
       - "6379:6379"
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "redis-cli", "--no-auth-warning", "-a", "squirrel", "ping"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -36,7 +37,7 @@ services:
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
     environment:
       SQUIRREL_DATABASE_URL: postgresql+asyncpg://squirrel:squirrel@db:5432/squirrel
-      SQUIRREL_REDIS_URL: redis://redis:6379/0
+      SQUIRREL_REDIS_URL: redis://:squirrel@redis:6379/0
       SQUIRREL_DEBUG: "true"
       # EPICS environment for SLAC prod access from dev network
       EPICS_CA_AUTO_ADDR_LIST: "NO"
@@ -75,7 +76,7 @@ services:
     command: python -m app.monitor_main
     environment:
       SQUIRREL_DATABASE_URL: postgresql+asyncpg://squirrel:squirrel@db:5432/squirrel
-      SQUIRREL_REDIS_URL: redis://redis:6379/0
+      SQUIRREL_REDIS_URL: redis://:squirrel@redis:6379/0
       SQUIRREL_DEBUG: "true"
       # EPICS environment
       EPICS_CA_AUTO_ADDR_LIST: "NO"
@@ -116,7 +117,7 @@ services:
     command: arq app.worker.WorkerSettings
     environment:
       SQUIRREL_DATABASE_URL: postgresql+asyncpg://squirrel:squirrel@db:5432/squirrel
-      SQUIRREL_REDIS_URL: redis://redis:6379/0
+      SQUIRREL_REDIS_URL: redis://:squirrel@redis:6379/0
       SQUIRREL_DEBUG: "true"
       # EPICS environment (needed for snapshot restore)
       EPICS_CA_AUTO_ADDR_LIST: "NO"
@@ -147,7 +148,7 @@ services:
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
     environment:
       SQUIRREL_DATABASE_URL: postgresql+asyncpg://squirrel:squirrel@db:5432/squirrel
-      SQUIRREL_REDIS_URL: redis://redis:6379/0
+      SQUIRREL_REDIS_URL: redis://:squirrel@redis:6379/0
       SQUIRREL_DEBUG: "true"
       # Enable embedded monitor for backward compatibility
       SQUIRREL_EMBEDDED_MONITOR: "true"


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
Add a **temporary** password to the redis server. We should eventually look into real passwords.

## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
SLAC IT was displeased with the number of redis servers on the network that didn't have a password set.

## Testing
I tested this using `redis-cli ping`. The results are below:
#### No password
```
react-squirrel-backend % docker exec squirrel-redis redis-cli ping            
NOAUTH Authentication required.
```
#### Wrong password
```
react-squirrel-backend % docker exec squirrel-redis redis-cli -a squirr ping  
NOAUTH Authentication required.

Warning: Using a password with '-a' or '-u' option on the command line interface may not be safe.
AUTH failed: WRONGPASS invalid username-password pair or user is disabled.
```
#### Right password
```
react-squirrel-backend % docker exec squirrel-redis redis-cli -a squirrel ping
Warning: Using a password with '-a' or '-u' option on the command line interface may not be safe.
PONG
```