### PR TITLE
FIX: Show PV count rather than total address count when displaying progress while saving a snapshot

### DIFF
--- a/app/services/snapshot_service.py
+++ b/app/services/snapshot_service.py
@@ -194,7 +194,8 @@ class SnapshotService:
         try:
             # Get all PVs and their addresses
             pv_addresses = await self.pv_repo.get_all_addresses()
-            logger.info(f"Found {len(pv_addresses)} PVs to snapshot")
+            total_pv_count = len(pv_addresses)
+            logger.info(f"Found {total_pv_count} PVs to snapshot")
 
             # Collect all unique addresses to read
             setpoint_map: dict[str, str] = {}  # address -> pv_id
@@ -207,11 +208,18 @@ class SnapshotService:
                     readback_map[readback] = pv_id
 
             all_addresses = list(set(setpoint_map.keys()) | set(readback_map.keys()))
-            logger.info(f"Reading {len(all_addresses)} unique EPICS addresses")
+            logger.info(f"Reading {len(all_addresses)} unique EPICS addresses for {total_pv_count} PVs")
+
+            # Create a wrapper progress callback that converts address progress to PV progress, so that users see
+            # about how many PVs are processed rather than total readbacks/setpoints
+            async def pv_progress_callback(current_addr: int, total_addr: int, message: str):
+                pv_progress_count = int((current_addr / total_addr) * total_pv_count) if total_addr > 0 else 0
+                pv_message = f"Read {pv_progress_count:,}/{total_pv_count:,} PVs"
+                await progress_callback(pv_progress_count, total_pv_count, pv_message)
 
             # Read all values from EPICS in parallel with progress reporting
             if progress_callback:
-                epics_values = await self.epics.get_many_with_progress(all_addresses, progress_callback)
+                epics_values = await self.epics.get_many_with_progress(all_addresses, pv_progress_callback)
             else:
                 epics_values = await self.epics.get_many(all_addresses)
 
@@ -230,7 +238,7 @@ class SnapshotService:
 
             # Report progress: EPICS read complete, starting database save
             if progress_callback:
-                await progress_callback(len(all_addresses), len(all_addresses), "Processing results...")
+                await progress_callback(total_pv_count, total_pv_count, "Processing results...")
 
             # Create snapshot record
             snapshot = Snapshot(title=data.title, comment=data.comment, created_by=created_by)
@@ -299,7 +307,7 @@ class SnapshotService:
             # Report progress: Saving to database
             if progress_callback:
                 await progress_callback(
-                    len(all_addresses), len(all_addresses), f"Saving {len(snapshot_values)} values to database..."
+                    total_pv_count, total_pv_count, f"Saving {len(snapshot_values):,} PV values to database..."
                 )
 
             # Bulk insert values with progress tracking for large datasets
@@ -342,10 +350,11 @@ class SnapshotService:
         try:
             # Get all PVs and their addresses
             pv_addresses = await self.pv_repo.get_all_addresses()
-            logger.info(f"Found {len(pv_addresses)} PVs to snapshot")
+            total_pv_count = len(pv_addresses)
+            logger.info(f"Found {total_pv_count} PVs to snapshot")
 
             if progress_callback:
-                await progress_callback(0, len(pv_addresses), "Reading from cache...")
+                await progress_callback(0, total_pv_count, "Reading from cache...")
 
             # Get all cached values from Redis as dicts (O(1) per value)
             cached_values = await self.redis.get_all_pv_values_as_dict()
@@ -459,7 +468,7 @@ class SnapshotService:
 
             if progress_callback:
                 await progress_callback(
-                    len(pv_addresses), len(pv_addresses), f"Saving {len(snapshot_values_data)} values to database..."
+                    total_pv_count, total_pv_count, f"Saving {len(snapshot_values_data):,} PV values to database..."
                 )
 
             # Use fast COPY insert


### PR DESCRIPTION
## Description

When saving a snapshot, the progress would display a larger number of PVs than would exist in the system or the final snapshot. This is because it was counting the total of all readbacks and setpoints rather than just PVs.

Fix is just to adjust this count to use the total PV count as a maximum when updating the progress meter.

## Motivation

Closes https://github.com/slaclab/react-squirrel/issues/9

## Screenshots

<img width="241" height="131" alt="Screenshot From 2026-02-02 11-58-48" src="https://github.com/user-attachments/assets/5dc2279f-6102-482c-9b00-7f1257984ce4" />

<img width="951" height="243" alt="Screenshot From 2026-02-02 12-06-42" src="https://github.com/user-attachments/assets/1d863289-c276-443d-8c23-46b75ce335c1" />
