### PR TITLE
FIX: APIException `code` Confusion

### DIFF
--- a/app/api/responses.py
+++ b/app/api/responses.py
@@ -24,7 +24,9 @@ def error_response(code: int, message: str, status_code: int = 400) -> JSONRespo
 class APIException(HTTPException):
     """Custom API exception with error codes."""
 
-    def __init__(self, code: int, message: str, status_code: int = 400):
+    def __init__(self, error_code: int, message: str, status_code: int | None = None):
+        if status_code is None:
+            status_code = error_code
         super().__init__(status_code=status_code, detail=message)
-        self.error_code = code
+        self.error_code = error_code
         self.error_message = message


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
Rename the confusingly named `code` parameter in the `APIException` class. Also `status_code` no longer defaults to 400, but to the same value as `error_code`

## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The error code value is intended to be an API specific error code, but I mistakenly put the HTTP Status codes in there more than once. Trying to relieve some confusion.

In the future we can consider making an Enum for API specific codes as well.

## Pre-merge checklist

- [x] Code works interactively
- [x] Code contains descriptive docstrings
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
