### PR TITLE
ENH: Prevent Deactivating Current Key

### DIFF
--- a/app/api/v1/api_keys.py
+++ b/app/api/v1/api_keys.py
@@ -1,7 +1,14 @@
 """API endpoints for API key management."""
-from fastapi import Security, APIRouter, HTTPException, status
+from typing import Annotated
 
-from app.dependencies import ApiKeyServiceDep, require_read_access, require_write_access
+from fastapi import Query, Security, APIRouter, HTTPException, status
+
+from app.dependencies import (
+    ApiKeyServiceDep,
+    get_api_key,
+    require_read_access,
+    require_write_access,
+)
 from app.schemas.api_key import ApiKeyDTO, ApiKeyCreateDTO, ApiKeyCreateResultDTO
 
 router = APIRouter(prefix="/api-keys", tags=["ApiKeys"])
@@ -32,8 +39,15 @@ async def create_api_key(
 async def deactivate_api_key(
     key_id: str,
     service: ApiKeyServiceDep,
+    current_key: Annotated[ApiKeyDTO, Security(get_api_key)],
+    force: bool = Query(default=False, description="Allow deactivation of the key currently used for authentication"),
 ) -> ApiKeyDTO:
-    """Deactivate an API Key by ID."""
+    """Deactivate an API Key by ID. Use ?force=true to deactivate the key currently used for authentication."""
+    if current_key.id == key_id and not force:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Cannot deactivate the API key currently used for authentication",
+        )
     try:
         deactivated = await service.deactivate_key(key_id)
         if deactivated is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,7 +122,7 @@ async def client(db_session: AsyncSession, mock_epics: MockEpicsService) -> Asyn
 
     async def override_get_api_key() -> ApiKeyDTO:
         return ApiKeyDTO(
-            id="test-key-id",
+            id="00000000-0000-0000-0000-000000000001",  # Test ID is valid UUID
             appName="TestClient",
             isActive=True,
             readAccess=True,

--- a/tests/test_api/test_api_keys.py
+++ b/tests/test_api/test_api_keys.py
@@ -267,3 +267,17 @@ class TestApiKeyDeactivate:
         new_key = response.json()
         assert new_key["id"] != key["id"]
         assert new_key["isActive"] is True
+
+    @pytest.mark.asyncio
+    async def test_deactivate_own_key_returns_409(self, client: AsyncClient):
+        """Deactivating the authenticated key is blocked without force."""
+        response = await client.delete("/v1/api-keys/00000000-0000-0000-0000-000000000001")
+
+        assert response.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_deactivate_own_key_with_force_succeeds(self, client: AsyncClient):
+        """Deactivating the authenticated key succeeds with ?force=true."""
+        response = await client.delete("/v1/api-keys/00000000-0000-0000-0000-000000000001", params={"force": "true"})
+
+        assert response.status_code == 404  # key doesn't exist in DB, but guard passed


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
Changes to `DELETE /v1/api-keys/{key_id}` endpoint: now prevents deletion of the key currently being used to authenticate the request. This will help prevent the scenario of users removing their own key by accident.

Also add a query parameter: `force`. This allows users to force the deactivation of their current key if it is intended.

## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #79 

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
FastAPI generated API References like Swagger and Redoc.

## Screenshots
<img width="603" height="384" alt="Screenshot 2026-04-30 at 13 24 05" src="https://github.com/user-attachments/assets/cd552380-ad66-48fd-b6a4-17e7c6db5c24" />

## Pre-merge checklist

- [x] Code works interactively
- [x] Code contains descriptive docstrings
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
