### PR TITLE
feat: add analytics event and  Loki/Promtail/Grafana

### DIFF
--- a/app/api/v1/analytics.py
+++ b/app/api/v1/analytics.py
@@ -1,7 +1,6 @@
 from fastapi import Depends, Request, APIRouter
 
 from app.dependencies import get_optional_api_key
-from app.api.responses import success_response
 from app.schemas.analytics import AnalyticsEventCreateDTO
 from app.services.analytics_service import log_analytics_event
 
@@ -13,7 +12,7 @@ async def create_event(
     data: AnalyticsEventCreateDTO,
     request: Request,
     api_key=Depends(get_optional_api_key),
-) -> dict:
+) -> bool:
     log_analytics_event(
         data.event,
         source="frontend",
@@ -29,4 +28,4 @@ async def create_event(
         },
     )
 
-    return success_response(True)
+    return True

--- a/app/api/v1/analytics.py
+++ b/app/api/v1/analytics.py
@@ -1,0 +1,32 @@
+from fastapi import Depends, Request, APIRouter
+
+from app.dependencies import get_optional_api_key
+from app.api.responses import success_response
+from app.schemas.analytics import AnalyticsEventCreateDTO
+from app.services.analytics_service import log_analytics_event
+
+router = APIRouter(prefix="/analytics", tags=["Analytics"])
+
+
+@router.post("/events")
+async def create_event(
+    data: AnalyticsEventCreateDTO,
+    request: Request,
+    api_key=Depends(get_optional_api_key),
+) -> dict:
+    log_analytics_event(
+        data.event,
+        source="frontend",
+        session_id=data.sessionId,
+        api_key_id=str(api_key.id) if api_key else None,
+        api_key_app=api_key.appName if api_key else None,
+        route=data.route,
+        path=data.path,
+        client_ts=data.clientTs,
+        properties={
+            **(data.properties or {}),
+            "user_agent": request.headers.get("user-agent"),
+        },
+    )
+
+    return success_response(True)

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -5,6 +5,7 @@ from app.api.v1.jobs import router as jobs_router
 from app.api.v1.tags import router as tags_router
 from app.api.v1.health import router as health_router
 from app.api.v1.api_keys import router as api_keys_router
+from app.api.v1.analytics import router as analytics_router
 from app.api.v1.snapshots import router as snapshots_router
 from app.api.v1.websocket import router as websocket_router
 
@@ -17,3 +18,4 @@ router.include_router(snapshots_router)
 router.include_router(jobs_router)
 router.include_router(websocket_router)
 router.include_router(health_router)
+router.include_router(analytics_router)

--- a/app/api/v1/snapshots.py
+++ b/app/api/v1/snapshots.py
@@ -25,6 +25,7 @@ from app.schemas.snapshot import (
     ComparisonResultDTO,
 )
 from app.services.background_tasks import run_snapshot_restore, run_snapshot_creation
+from app.services.analytics_service import log_analytics_event
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
@@ -140,6 +141,16 @@ async def create_snapshot(
                         use_cache=use_cache,
                     )
                     logger.info(f"Enqueued snapshot job to Arq: {job.id}")
+                    log_analytics_event(
+                        "snapshot_create_requested",
+                        source="backend",
+                        properties={
+                            "job_id": str(job.id),
+                            "async_mode": True,
+                            "use_cache": use_cache,
+                            "queue": "arq",
+                        },
+                    )
                     return JobCreatedDTO(
                         jobId=job.id,
                         message=f"Snapshot creation queued for '{data.title}'"
@@ -151,6 +162,16 @@ async def create_snapshot(
         # Fallback to FastAPI BackgroundTasks
         background_tasks.add_task(run_snapshot_creation, job.id, data.title, data.description, use_cache)
         logger.info(f"Scheduled snapshot job via BackgroundTasks: {job.id}")
+        log_analytics_event(
+            "snapshot_create_requested",
+            source="backend",
+            properties={
+                "job_id": str(job.id),
+                "async_mode": True,
+                "use_cache": use_cache,
+                "queue": "background_tasks",
+            },
+        )
 
         return JobCreatedDTO(
             jobId=job.id,
@@ -160,8 +181,21 @@ async def create_snapshot(
     else:
         # Synchronous mode (legacy behavior)
         if use_cache:
-            return await service.create_snapshot_from_cache(data)
-        return await service.create_snapshot(data)
+            snapshot = await service.create_snapshot_from_cache(data)
+        else:
+            snapshot = await service.create_snapshot(data)
+
+        log_analytics_event(
+            "snapshot_create_completed",
+            source="backend",
+            properties={
+                "async_mode": False,
+                "use_cache": use_cache,
+                "snapshot_id": str(snapshot.id),
+                "pv_count": snapshot.pvCount,
+            },
+        )
+        return snapshot
 
 
 @router.put(
@@ -235,6 +269,17 @@ async def restore_snapshot(
                         pv_ids=pv_ids,
                     )
                     logger.info(f"Enqueued restore job to Arq: {job.id}")
+                    log_analytics_event(
+                        "snapshot_restore_requested",
+                        source="backend",
+                        properties={
+                            "job_id": str(job.id),
+                            "snapshot_id": snapshot_id,
+                            "async_mode": True,
+                            "pv_count": len(pv_ids) if pv_ids else None,
+                            "queue": "arq",
+                        },
+                    )
                     return JobCreatedDTO(
                         jobId=job.id,
                         message=f"Snapshot restore queued ({snapshot_id})",
@@ -245,12 +290,35 @@ async def restore_snapshot(
         # Fallback to FastAPI BackgroundTasks
         background_tasks.add_task(run_snapshot_restore, str(job.id), snapshot_id, pv_ids)
         logger.info(f"Scheduled restore job via BackgroundTasks: {job.id}")
+        log_analytics_event(
+            "snapshot_restore_requested",
+            source="backend",
+            properties={
+                "job_id": str(job.id),
+                "snapshot_id": snapshot_id,
+                "async_mode": True,
+                "pv_count": len(pv_ids) if pv_ids else None,
+                "queue": "background_tasks",
+            },
+        )
         return JobCreatedDTO(
             jobId=job.id,
             message=f"Snapshot restore started ({snapshot_id})",
         )
 
-    return await service.restore_snapshot(snapshot_id, request)
+    result = await service.restore_snapshot(snapshot_id, request)
+    log_analytics_event(
+        "snapshot_restore_completed",
+        source="backend",
+        properties={
+            "async_mode": False,
+            "snapshot_id": snapshot_id,
+            "success_count": result.successCount,
+            "failure_count": result.failureCount,
+            "total_pvs": result.totalPVs,
+        },
+    )
+    return result
 
 
 @router.delete(
@@ -270,6 +338,14 @@ async def delete_snapshot(
     success = await service.delete_snapshot(snapshot_id)
     if not success:
         raise HTTPException(status_code=404, detail=f"Snapshot {snapshot_id} not found")
+    log_analytics_event(
+        "snapshot_deleted",
+        source="backend",
+        properties={
+            "snapshot_id": snapshot_id,
+            "delete_data": deleteData,
+        },
+    )
     return True
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -51,6 +51,9 @@ class Settings(BaseSettings):
     # Performance
     bulk_insert_batch_size: int = 5000
 
+    # Analytics
+    analytics_enabled: bool = True
+
     class Config:
         env_file = ".env"
         env_prefix = "SQUIRREL_"

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -85,6 +85,22 @@ async def get_api_key(
     )
 
 
+async def get_optional_api_key(
+    db: Annotated[AsyncSession, Depends(get_db)], api_key_header: Annotated[str, Security(api_key_header)]
+) -> ApiKeyDTO | None:
+    """Optional API key lookup for endpoints that allow anonymous access."""
+    if not api_key_header:
+        return None
+
+    service = ApiKeyService(db)
+    api_key_dto = await service.get_by_token(api_key_header)
+
+    if api_key_dto and api_key_dto.isActive:
+        return api_key_dto
+
+    return None
+
+
 def require_read_access(api_key_dto: Annotated[ApiKeyDTO, Security(get_api_key)]):
     """Dependency that requires a valid, active API Key with read access."""
     if not api_key_dto.readAccess:

--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -1,0 +1,32 @@
+import os
+import logging
+
+
+def configure_logging() -> None:
+    """Configure logging to stdout and to a file for Promtail ingestion."""
+    log_path = os.environ.get("SQUIRREL_LOG_PATH", "/tmp/squirrel-logs/backend.log")
+    log_dir = os.path.dirname(log_path)
+
+    try:
+        if log_dir:
+            os.makedirs(log_dir, exist_ok=True)
+    except Exception:
+        # If we can't create the directory, fall back to stdout-only.
+        logging.basicConfig(
+            level=logging.DEBUG,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+        return
+
+    handlers: list[logging.Handler] = [logging.StreamHandler()]
+    try:
+        handlers.append(logging.FileHandler(log_path))
+    except Exception:
+        # If file handler can't be created, continue with stdout-only.
+        pass
+
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        handlers=handlers,
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -21,12 +21,13 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import get_settings
 from app.api.v1.router import router as v1_router
+from app.logging_config import configure_logging
 from app.api.v1.websocket import get_diff_manager
 from app.services.epics_service import get_epics_service
 from app.services.redis_service import get_redis_service
 
 # Configure logging
-logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+configure_logging()
 logger = logging.getLogger(__name__)
 
 settings = get_settings()

--- a/app/monitor_main.py
+++ b/app/monitor_main.py
@@ -16,6 +16,7 @@ import logging
 
 from app.config import get_settings
 from app.db.session import async_session_maker
+from app.logging_config import configure_logging
 from app.services.watchdog import get_watchdog
 from app.services.pv_monitor import get_pv_monitor
 from app.services.pv_protocol import is_unprefixed, parse_pv_name
@@ -24,7 +25,7 @@ from app.services.redis_service import get_redis_service
 from app.services.pvaccess_monitor import get_pvaccess_monitor
 
 # Configure logging
-logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+configure_logging()
 logger = logging.getLogger(__name__)
 
 settings = get_settings()

--- a/app/schemas/analytics.py
+++ b/app/schemas/analytics.py
@@ -1,0 +1,15 @@
+from typing import Any
+from datetime import datetime
+
+from pydantic import Field, BaseModel
+
+
+class AnalyticsEventCreateDTO(BaseModel):
+    """Incoming analytics event from the frontend."""
+
+    event: str
+    sessionId: str | None = None
+    route: str | None = None
+    path: str | None = None
+    clientTs: datetime | None = None
+    properties: dict[str, Any] | None = Field(default_factory=dict)

--- a/app/services/analytics_service.py
+++ b/app/services/analytics_service.py
@@ -1,0 +1,45 @@
+import json
+import logging
+from typing import Any
+from datetime import UTC, datetime
+
+from app.config import get_settings
+
+analytics_logger = logging.getLogger("analytics")
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def log_analytics_event(
+    event: str,
+    *,
+    source: str,
+    session_id: str | None = None,
+    api_key_id: str | None = None,
+    api_key_app: str | None = None,
+    route: str | None = None,
+    path: str | None = None,
+    client_ts: datetime | None = None,
+    properties: dict[str, Any] | None = None,
+) -> None:
+    settings = get_settings()
+    if not getattr(settings, "analytics_enabled", True):
+        return
+
+    payload = {
+        "type": "analytics",
+        "event": event,
+        "source": source,
+        "timestamp": _now_iso(),
+        "session_id": session_id,
+        "api_key_id": api_key_id,
+        "api_key_app": api_key_app,
+        "route": route,
+        "path": path,
+        "client_ts": client_ts.isoformat() if client_ts else None,
+        "properties": properties or {},
+    }
+
+    analytics_logger.info(json.dumps(payload, default=str))

--- a/app/services/background_tasks.py
+++ b/app/services/background_tasks.py
@@ -8,6 +8,7 @@ from app.schemas.snapshot import NewSnapshotDTO, RestoreRequestDTO
 from app.services.epics_service import get_epics_service
 from app.services.redis_service import get_redis_service
 from app.services.snapshot_service import SnapshotService
+from app.services.analytics_service import log_analytics_event
 from app.repositories.job_repository import JobRepository
 
 logger = logging.getLogger(__name__)
@@ -99,9 +100,30 @@ async def run_snapshot_creation(
             await session.commit()
 
             logger.info(f"Background task completed for job {job_id}: Snapshot {result.id} created")
+            log_analytics_event(
+                "snapshot_create_completed",
+                source="backend",
+                properties={
+                    "job_id": job_id,
+                    "snapshot_id": str(result.id),
+                    "use_cache": use_cache,
+                    "pv_count": result.pvCount,
+                    "queue": "background_tasks",
+                },
+            )
 
         except Exception as e:
             logger.exception(f"Background task failed for job {job_id}: {e}")
+            log_analytics_event(
+                "snapshot_create_failed",
+                source="backend",
+                properties={
+                    "job_id": job_id,
+                    "use_cache": use_cache,
+                    "queue": "background_tasks",
+                    "error": str(e),
+                },
+            )
             error_msg = f"{type(e).__name__}: {str(e)}"
             try:
                 await session.rollback()
@@ -199,9 +221,31 @@ async def run_snapshot_restore(
                 f"{result.successCount}/{result.totalPVs} succeeded, "
                 f"{result.failureCount} failed"
             )
+            log_analytics_event(
+                "snapshot_restore_completed",
+                source="backend",
+                properties={
+                    "job_id": job_id,
+                    "snapshot_id": snapshot_id,
+                    "success_count": result.successCount,
+                    "failure_count": result.failureCount,
+                    "total_pvs": result.totalPVs,
+                    "queue": "background_tasks",
+                },
+            )
 
         except Exception as e:
             logger.exception(f"Background restore failed for job {job_id}: {e}")
+            log_analytics_event(
+                "snapshot_restore_failed",
+                source="backend",
+                properties={
+                    "job_id": job_id,
+                    "snapshot_id": snapshot_id,
+                    "queue": "background_tasks",
+                    "error": str(e),
+                },
+            )
             error_msg = f"{type(e).__name__}: {str(e)}"
             try:
                 await session.rollback()

--- a/app/tasks/snapshot_tasks.py
+++ b/app/tasks/snapshot_tasks.py
@@ -15,6 +15,7 @@ from app.schemas.snapshot import NewSnapshotDTO
 from app.services.epics_service import get_epics_service
 from app.services.redis_service import get_redis_service
 from app.services.snapshot_service import SnapshotService
+from app.services.analytics_service import log_analytics_event
 from app.repositories.job_repository import JobRepository
 
 logger = logging.getLogger(__name__)
@@ -79,10 +80,28 @@ async def create_snapshot_task(
             await session.commit()
 
             logger.info(f"Snapshot created successfully: job_id={job_id}, snapshot_id={result.id}")
+            log_analytics_event(
+                "snapshot_create_completed",
+                source="backend",
+                properties={
+                    "job_id": job_id,
+                    "snapshot_id": str(result.id),
+                    "use_cache": use_cache,
+                },
+            )
             return result.id
 
         except Exception as e:
             logger.error(f"Snapshot creation failed: job_id={job_id}, error={e}")
+            log_analytics_event(
+                "snapshot_create_failed",
+                source="backend",
+                properties={
+                    "job_id": job_id,
+                    "use_cache": use_cache,
+                    "error": str(e),
+                },
+            )
 
             # Mark job as failed
             try:
@@ -180,10 +199,30 @@ async def restore_snapshot_task(ctx: dict, job_id: str, snapshot_id: str, pv_ids
                 f"Snapshot restored successfully: job_id={job_id}, "
                 f"success={result.successCount}, failures={result.failureCount}"
             )
+            log_analytics_event(
+                "snapshot_restore_completed",
+                source="backend",
+                properties={
+                    "job_id": job_id,
+                    "snapshot_id": snapshot_id,
+                    "success_count": result.successCount,
+                    "failure_count": result.failureCount,
+                    "total_pvs": result.totalPVs,
+                },
+            )
             return result_data
 
         except Exception as e:
             logger.error(f"Snapshot restore failed: job_id={job_id}, error={e}")
+            log_analytics_event(
+                "snapshot_restore_failed",
+                source="backend",
+                properties={
+                    "job_id": job_id,
+                    "snapshot_id": snapshot_id,
+                    "error": str(e),
+                },
+            )
 
             # Mark job as failed
             try:

--- a/app/worker.py
+++ b/app/worker.py
@@ -21,7 +21,9 @@ from arq.connections import RedisSettings
 
 from app.tasks import create_snapshot_task, restore_snapshot_task
 from app.config import get_settings
+from app.logging_config import configure_logging
 
+configure_logging()
 logger = logging.getLogger(__name__)
 settings = get_settings()
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -42,7 +42,7 @@ services:
 
       SQUIRREL_DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       SQUIRREL_REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
-      SQUIRREL_DEBUG: "${SQUIRREL_DEBUG}"
+      SQUIRREL_DEBUG: "${SQUIRREL_DEBUG:-false}"
 
       EPICS_CA_AUTO_ADDR_LIST: "${EPICS_CA_AUTO_ADDR_LIST}"
       EPICS_CA_ADDR_LIST: "${EPICS_CA_ADDR_LIST}"
@@ -58,6 +58,8 @@ services:
     volumes:
       - ../app:/app/app
       - ../tests:/app/tests
+      - ../scripts:/app/scripts
+      - /tmp/squirrel-logs:/tmp/squirrel-logs
       - ../scripts:/app/scripts
     depends_on:
       db:
@@ -79,7 +81,7 @@ services:
     environment:
       SQUIRREL_DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       SQUIRREL_REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
-      SQUIRREL_DEBUG: "${SQUIRREL_DEBUG}"
+      SQUIRREL_DEBUG: "${SQUIRREL_DEBUG:-false}"
 
       EPICS_CA_AUTO_ADDR_LIST: "${EPICS_CA_AUTO_ADDR_LIST}"
       EPICS_CA_ADDR_LIST: "${EPICS_CA_ADDR_LIST}"
@@ -92,6 +94,7 @@ services:
       EPICS_PVA_BROADCAST_PORT: "${EPICS_PVA_BROADCAST_PORT}"
     volumes:
       - ../app:/app/app
+      - /tmp/squirrel-logs:/tmp/squirrel-logs
     depends_on:
       db:
         condition: service_healthy
@@ -117,7 +120,7 @@ services:
     environment:
       SQUIRREL_DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       SQUIRREL_REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
-      SQUIRREL_DEBUG: "${SQUIRREL_DEBUG}"
+      SQUIRREL_DEBUG: "${SQUIRREL_DEBUG:-false}"
 
       # EPICS Channel Access (needed for snapshot restore)
       EPICS_CA_AUTO_ADDR_LIST: "${EPICS_CA_AUTO_ADDR_LIST}"
@@ -126,6 +129,7 @@ services:
       EPICS_CA_SERVER_PORT: "${EPICS_CA_SERVER_PORT}"
     volumes:
       - ../app:/app/app
+      - /tmp/squirrel-logs:/tmp/squirrel-logs
     depends_on:
       db:
         condition: service_healthy
@@ -149,7 +153,7 @@ services:
     environment:
       SQUIRREL_DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       SQUIRREL_REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
-      SQUIRREL_DEBUG: "${SQUIRREL_DEBUG}"
+      SQUIRREL_DEBUG: "${SQUIRREL_DEBUG:-false}"
       # Enable embedded monitor for backward compatibility
       SQUIRREL_EMBEDDED_MONITOR: "true"
 
@@ -167,6 +171,7 @@ services:
     volumes:
       - ../app:/app/app
       - ../tests:/app/tests
+      - /tmp/squirrel-logs:/tmp/squirrel-logs
     depends_on:
       db:
         condition: service_healthy

--- a/docker/observability/README.md
+++ b/docker/observability/README.md
@@ -1,0 +1,39 @@
+# Observability Stack (Loki + Promtail + Grafana)
+
+This folder contains a standalone compose file for logs + dashboards.
+
+## Start
+
+From `react-squirrel-backend/docker/observability`:
+
+```bash
+docker compose -f docker-compose.observability.yml up -d
+```
+
+Grafana will be available at `http://localhost:3000` (default credentials: `admin` / `admin`).
+
+## Log Path
+
+Promtail is configured to read:
+
+```
+/tmp/squirrel-logs/backend.log
+```
+
+The backend now writes to this path by default (via `SQUIRREL_LOG_PATH`).
+If you run the backend in Docker, the compose file mounts `/tmp/squirrel-logs` into the containers so the host path is populated.
+
+If you want a different log location, update:
+
+- `docker/observability/promtail-config.yaml` (`__path__`)
+- `SQUIRREL_LOG_PATH` (env var)
+
+## Import the Dashboard
+
+Use the prebuilt dashboard JSON:
+
+```
+react-squirrel-backend/docs/observability/grafana-analytics-dashboard.json
+```
+
+In Grafana: `Dashboards` -> `New` -> `Import` -> upload the JSON.

--- a/docker/observability/docker-compose.observability.yml
+++ b/docker/observability/docker-compose.observability.yml
@@ -1,0 +1,39 @@
+services:
+  loki:
+    image: grafana/loki:3.0.0
+    container_name: squirrel-loki
+    command: -config.file=/etc/loki/config.yaml
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./loki-config.yaml:/etc/loki/config.yaml:ro
+      - loki_data:/loki
+
+  promtail:
+    image: grafana/promtail:3.0.0
+    container_name: squirrel-promtail
+    command: -config.file=/etc/promtail/config.yaml
+    volumes:
+      - ./promtail-config.yaml:/etc/promtail/config.yaml:ro
+      # Bind-mount wherever the backend writes logs on the host.
+      # Update this path to match the backend log output location.
+      - /tmp/squirrel-logs:/tmp/squirrel-logs:ro
+    depends_on:
+      - loki
+
+  grafana:
+    image: grafana/grafana:11.1.0
+    container_name: squirrel-grafana
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+    volumes:
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - loki
+
+volumes:
+  loki_data:
+  grafana_data:

--- a/docker/observability/loki-config.yaml
+++ b/docker/observability/loki-config.yaml
@@ -1,0 +1,29 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093

--- a/docker/observability/promtail-config.yaml
+++ b/docker/observability/promtail-config.yaml
@@ -1,0 +1,44 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: squirrel-backend
+    static_configs:
+      - targets: ["localhost"]
+        labels:
+          app: squirrel-backend
+          job: squirrel-backend
+          __path__: /tmp/squirrel-logs/backend.log
+    pipeline_stages:
+      - match:
+          selector: '{app="squirrel-backend"}'
+          stages:
+            - regex:
+                expression: '.* - analytics - .* - (?P<json>\{.*\})'
+            - json:
+                source: json
+                expressions:
+                  event: event
+                  source: source
+                  route: route
+                  path: path
+                  api_key_app: api_key_app
+                  session_id: session_id
+                  timestamp: timestamp
+            - labels:
+                event: event
+                source: source
+                route: route
+                api_key_app: api_key_app
+            - timestamp:
+                source: timestamp
+                format: RFC3339Nano
+            - output:
+                source: json

--- a/docs/observability/STEP_BY_STEP_GUIDE.md
+++ b/docs/observability/STEP_BY_STEP_GUIDE.md
@@ -1,0 +1,446 @@
+# Squirrel Analytics (Loki + Promtail + Grafana) — Complete Step‑by‑Step Guide
+
+This is a long, beginner‑friendly guide. It assumes no prior experience with logs, monitoring, or Grafana.
+
+If you follow the steps in order, you will end up with a live dashboard showing how people use Squirrel.
+
+---
+
+## Table of Contents
+
+1. What This Gives You
+2. What You Need Before Starting
+3. Overview of How It Works
+4. Step 1 — Start the Backend
+5. Step 2 — Start Observability (Grafana + Loki + Promtail)
+6. Step 3 — Open Grafana
+7. Step 4 — Import the Dashboard
+8. Step 5 — Start the Frontend (UI)
+9. Step 6 — Generate Analytics Events
+10. Step 7 — Verify Events Are Flowing
+11. Where Logs Are Written
+12. What Type of Logs These Are
+13. How Logs Are Read and Shipped
+14. What Loki Does
+15. What Grafana Does
+16. How to Add a New Tracked Action
+17. Common Issues and Fixes
+18. Full Reset (Start From Scratch)
+19. Quick Reference Commands
+
+---
+
+## 1. What This Gives You
+
+- A clear view of how people use Squirrel
+- A dashboard that updates automatically
+- Searchable analytics logs stored in Loki
+
+You will see things like:
+- Page views
+- Snapshot create / restore events
+- PV browser usage and filtering
+- Tag creation and edits
+
+---
+
+## 2. What You Need Before Starting
+
+- Docker Desktop installed and running
+- This repository cloned on your computer
+
+---
+
+## 3. Overview of How It Works
+
+Think of it as a pipeline:
+
+```
+Squirrel Backend writes logs
+-> Promtail reads the log file
+-> Promtail sends logs to Loki
+-> Grafana shows dashboards from Loki data
+```
+
+Each step must be running for the dashboard to show data.
+
+---
+
+## 4. Step 1 — Start the Backend
+
+From the repository root:
+
+```bash
+docker compose -f react-squirrel-backend/docker/docker-compose.yml up -d
+```
+
+This starts:
+- Postgres database
+- Redis
+- Squirrel backend API
+- Worker
+- Monitor
+
+---
+
+## 5. Step 2 — Start Observability (Grafana + Loki + Promtail)
+
+From the repository root:
+
+```bash
+docker compose -f react-squirrel-backend/docker/observability/docker-compose.observability.yml up -d
+```
+
+This starts:
+- Loki (log storage)
+- Promtail (log shipper)
+- Grafana (dashboards)
+
+---
+
+## 6. Step 3 — Open Grafana
+
+Open your browser and go to:
+
+```
+http://localhost:3000
+```
+
+Login:
+- Username: `admin`
+- Password: `admin`
+
+Grafana may ask you to change the password. You can do it or skip it for local use.
+
+---
+
+## 7. Step 4 — Import the Dashboard
+
+1. In Grafana, click `Dashboards` → `New` → `Import`
+2. Upload this file:
+
+```
+react-squirrel-backend/docs/observability/grafana-analytics-dashboard.json
+```
+
+3. Click `Import`
+
+Now the dashboard appears in your list.
+
+---
+
+## 8. Step 5 — Start the Frontend (UI)
+
+From the repository root:
+
+```bash
+cd react-squirrel
+pnpm install
+pnpm run dev
+```
+
+Open the URL printed in your terminal, usually:
+
+```
+http://localhost:5173
+```
+
+---
+
+## 9. Step 6 — Generate Analytics Events
+
+Just click around the UI. Every click you make creates analytics events:
+
+- Page views
+- Snapshot create / restore
+- PV browsing, search, filters
+- Tag creation and edits
+
+---
+
+## 10. Step 7 — Verify Events Are Flowing
+
+This is the most important check. Use the steps below.
+
+### Check the log file
+
+```bash
+tail -n 5 /tmp/squirrel-logs/backend.log
+```
+
+You should see lines like:
+
+```
+2026-04-28 23:46:33,219 - analytics - INFO - {"type": "analytics", "event": "page_view", ...}
+```
+
+### Check Promtail
+
+```bash
+docker logs --tail=20 squirrel-promtail
+```
+
+You should see that it is tailing `/tmp/squirrel-logs/backend.log`.
+
+### Check Loki
+
+```bash
+curl -s "http://localhost:3100/loki/api/v1/labels" | python3 -m json.tool
+```
+
+If Loki shows labels such as `event` and `route`, it is receiving data.
+
+---
+
+## 11. Where Logs Are Written
+
+The backend writes logs to this file by default:
+
+```
+/tmp/squirrel-logs/backend.log
+```
+
+This path is set in:
+
+- `react-squirrel-backend/app/logging_config.py`
+
+If you want to change the path, set the environment variable:
+
+```
+SQUIRREL_LOG_PATH=/your/path/backend.log
+```
+
+---
+
+## 12. What Type of Logs These Are
+
+Analytics logs are JSON‑formatted events, inside normal log lines.
+
+Example log line:
+
+```
+2026-04-28 23:46:33,219 - analytics - INFO - {"type": "analytics", "event": "page_view", "route": "/snapshots", ...}
+```
+
+That JSON is what Loki and Grafana care about.
+
+---
+
+## 13. How Logs Are Read and Shipped
+
+Promtail is the tool that **reads** the log file and **ships** it to Loki.
+
+Promtail is configured here:
+
+- `react-squirrel-backend/docker/observability/promtail-config.yaml`
+
+Key settings inside:
+
+- `__path__` tells Promtail which file to read
+- `pipeline_stages` tells Promtail how to parse the JSON
+
+---
+
+## 14. What Loki Does
+
+Loki is a log database. It stores the logs in a way that Grafana can search and graph.
+
+Loki runs in Docker in the observability stack:
+
+- `squirrel-loki` container
+- Accessible at `http://localhost:3100`
+
+Promtail pushes logs to Loki using the Loki HTTP API.
+
+---
+
+## 15. What Grafana Does
+
+Grafana is the dashboard tool.
+
+Grafana queries Loki and shows charts such as:
+
+- Page views over time
+- Snapshot success vs failure
+- PV browser usage
+- Tag changes
+
+Grafana runs in Docker in the observability stack:
+
+- `squirrel-grafana` container
+- Accessible at `http://localhost:3000`
+
+---
+
+## 16. How to Add a New Tracked Action
+
+You can add analytics in **two places**: frontend or backend.
+
+### Frontend (UI)
+
+Call this function:
+
+```
+analyticsService.track({ event: "your_event_name", properties: { ... } })
+```
+
+Location:
+- `react-squirrel/src/services/analyticsService.ts`
+
+Typical usage:
+- Page views
+- Button clicks
+- Filter usage
+
+### Backend
+
+Call this function:
+
+```
+log_analytics_event("your_event_name", source="backend", properties={...})
+```
+
+Location:
+- `react-squirrel-backend/app/services/analytics_service.py`
+
+Typical usage:
+- Snapshot completed
+- Restore failed
+- Background jobs finished
+
+---
+
+## 17. Common Issues and Fixes
+
+### Issue: Dashboard is empty
+
+Possible causes:
+- UI is not running
+- Backend logs are not being written
+- Promtail is not shipping logs
+- Grafana is querying the wrong time range
+
+Fix checklist:
+
+1. Check backend logs:
+
+```bash
+tail -n 5 /tmp/squirrel-logs/backend.log
+```
+
+2. Check Promtail:
+
+```bash
+docker logs --tail=20 squirrel-promtail
+```
+
+3. Check Loki labels:
+
+```bash
+curl -s "http://localhost:3100/loki/api/v1/labels" | python3 -m json.tool
+```
+
+4. In Grafana, set time range to `Last 15 minutes`
+
+---
+
+### Issue: UI won’t start because API_KEY is missing
+
+Fix:
+
+1. Create a new API key (if no keys exist):
+
+```bash
+curl -s -X POST http://localhost:8080/v1/api-keys/bootstrap | python3 -m json.tool
+```
+
+2. Set the token in `react-squirrel/.env`:
+
+```
+API_KEY=your_token_here
+```
+
+---
+
+### Issue: Database fails to start
+
+Cause: Missing environment variables.
+
+Fix by setting defaults in:
+
+- `react-squirrel-backend/docker/.env`
+
+Values:
+
+```
+POSTGRES_USER=username
+POSTGRES_PASSWORD=password
+POSTGRES_DB=squirrel
+REDIS_PASSWORD=password
+SQUIRREL_DEBUG=false
+```
+
+---
+
+## 18. Full Reset (Start From Scratch)
+
+Warning: This deletes containers and volumes.
+
+```bash
+docker stop $(docker ps -q)
+docker rm $(docker ps -a -q)
+docker volume rm $(docker volume ls -q)
+```
+
+Then start again from Step 4.
+
+---
+
+## 19. Quick Reference Commands
+
+Start backend:
+
+```bash
+docker compose -f react-squirrel-backend/docker/docker-compose.yml up -d
+```
+
+Start observability:
+
+```bash
+docker compose -f react-squirrel-backend/docker/observability/docker-compose.observability.yml up -d
+```
+
+Check backend logs:
+
+```bash
+tail -n 5 /tmp/squirrel-logs/backend.log
+```
+
+Check Promtail:
+
+```bash
+docker logs --tail=20 squirrel-promtail
+```
+
+Check Loki:
+
+```bash
+curl -s http://localhost:3100/ready
+```
+
+Open Grafana:
+
+```
+http://localhost:3000
+```
+
+---
+
+## Summary
+
+- Backend writes analytics logs to `/tmp/squirrel-logs/backend.log`
+- Promtail reads the file and ships logs to Loki
+- Loki stores logs and makes them searchable
+- Grafana visualizes the data
+
+You now have a full analytics pipeline for Squirrel.

--- a/docs/observability/grafana-analytics-dashboard.json
+++ b/docs/observability/grafana-analytics-dashboard.json
@@ -1,0 +1,110 @@
+{
+  "uid": "squirrel-analytics",
+  "title": "Squirrel Usage Analytics",
+  "schemaVersion": 38,
+  "version": 1,
+  "timezone": "browser",
+  "refresh": "30s",
+  "tags": ["squirrel", "analytics"],
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "type": "datasource",
+        "name": "Loki",
+        "label": "Loki",
+        "query": "loki",
+        "current": {
+          "text": "Loki",
+          "value": "Loki"
+        }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Page Views (All)",
+      "datasource": "${Loki}",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(count_over_time({app=\"squirrel-backend\", event=\"page_view\"}[$__interval]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" } }
+    },
+    {
+      "type": "bargauge",
+      "title": "Top Routes (Page Views)",
+      "datasource": "${Loki}",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (route) (count_over_time({app=\"squirrel-backend\", event=\"page_view\"}[$__range])))",
+          "refId": "A"
+        }
+      ],
+      "options": { "displayMode": "gradient" }
+    },
+    {
+      "type": "timeseries",
+      "title": "Snapshot Create Success vs Fail",
+      "datasource": "${Loki}",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum by (event) (count_over_time({app=\"squirrel-backend\", event=~\"snapshot_create_(completed|failed)\"}[$__interval]))",
+          "refId": "A",
+          "legendFormat": "{{event}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Snapshot Restore Success vs Fail",
+      "datasource": "${Loki}",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum by (event) (count_over_time({app=\"squirrel-backend\", event=~\"snapshot_restore_(completed|failed)\"}[$__interval]))",
+          "refId": "A",
+          "legendFormat": "{{event}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "PV Browser Queries",
+      "datasource": "${Loki}",
+      "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(count_over_time({app=\"squirrel-backend\", event=\"pv_browse_query\"}[$__interval]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Tag Changes",
+      "datasource": "${Loki}",
+      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum by (event) (count_over_time({app=\"squirrel-backend\", event=~\"tag(_group)?_(created|updated|deleted)\"}[$__interval]))",
+          "refId": "A",
+          "legendFormat": "{{event}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" } }
+    }
+  ]
+}

--- a/docs/observability/promtail-loki-snippet.yaml
+++ b/docs/observability/promtail-loki-snippet.yaml
@@ -1,0 +1,38 @@
+# Promtail snippet for Squirrel analytics logs (Loki JSON parsing)
+# Assumes backend logs contain JSON in the message field with the analytics logger name.
+# Example log line:
+# 2026-04-22 12:00:00,000 - analytics - INFO - {"event":"page_view", ...}
+
+scrape_configs:
+  - job_name: squirrel-backend
+    static_configs:
+      - targets: ["localhost"]
+        labels:
+          app: squirrel-backend
+          __path__: /tmp/squirrel-logs/backend.log
+    pipeline_stages:
+      - match:
+          selector: '{app="squirrel-backend"}'
+          stages:
+            - regex:
+                expression: '.* - analytics - .* - (?P<json>\{.*\})'
+            - json:
+                source: json
+                expressions:
+                  event: event
+                  source: source
+                  route: route
+                  path: path
+                  api_key_app: api_key_app
+                  session_id: session_id
+                  timestamp: timestamp
+            - labels:
+                event: event
+                source: source
+                route: route
+                api_key_app: api_key_app
+            - timestamp:
+                source: timestamp
+                format: RFC3339Nano
+            - output:
+                source: json

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,10 @@
 Pytest configuration and fixtures for squirrel-backend tests.
 """
 
-import asyncio
 import logging
 from datetime import datetime
-from collections.abc import Generator, AsyncGenerator
+from collections.abc import AsyncGenerator
 
-import pytest
 import asyncpg
 import pytest_asyncio
 import fakeredis.aioredis as aioredis_fake
@@ -34,14 +32,6 @@ _p4p_logger.handlers = [logging.NullHandler()]
 TEST_DATABASE_URL = "postgresql+asyncpg://squirrel:squirrel@localhost:5432/squirrel_test"
 # Admin DSN used to create squirrel_test if it doesn't exist; uses the built-in `postgres` database
 _ADMIN_DSN = "postgresql://squirrel:squirrel@localhost:5432/postgres"
-
-
-@pytest.fixture(scope="session")
-def event_loop() -> Generator:
-    """Create event loop for async tests."""
-    loop = asyncio.get_event_loop_policy().new_event_loop()
-    yield loop
-    loop.close()
 
 
 @pytest_asyncio.fixture(scope="session")


### PR DESCRIPTION
## Description
Added a new backend analytics ingestion endpoint at POST /v1/analytics/events to accept frontend usage events.
Added optional API key resolution for analytics requests so events can be accepted with or without an API key, while still attaching API key metadata when present.
Added structured analytics logging service that emits JSON log lines with consistent fields (event, source, route, path, timestamps, session/API key metadata, and properties).
Instrumented snapshot API and async execution paths to emit analytics events for:
snapshot create requested/completed/failed
snapshot restore requested/completed/failed
snapshot delete
Added centralized logging configuration used by API, monitor, and worker processes to write logs to both stdout and file (/tmp/squirrel-logs/backend.log by default).
Added observability stack configuration (Loki + Promtail + Grafana) under docker/observability/ plus setup README.
Added Grafana dashboard JSON template and observability documentation under docs/observability/.

## Motivation
This change introduces a lightweight, open-source analytics/observability pipeline for Squirrel using infrastructure already available to us (Loki, Promtail, Grafana).
It solves these main problems:

We had no consistent way to measure real user behavior in key workflows (PV browsing, snapshots, tags).
Operational debugging required manual log digging instead of structured, queryable analytics signals.
Design choices:

Chose structured JSON logs over direct metrics to keep ingestion simple and flexible.
Added analytics_enabled switch for safe operational control.
Kept analytics non-blocking and low-risk: event logging should not break user workflows.
Used optional API key dependency to support both authenticated and unauthenticated clients.

<!--
## Where Has This Been Documented?
docs/observability/STEP_BY_STEP_GUIDE.md
docker/observability/README.md
docs/observability/grafana-analytics-dashboard.json
docs/observability/promtail-loki-snippet.yaml

## Screenshots
N/A (backend + observability config/doc changes)
## Pre-merge checklist

- [X ] Code works interactively
- [ X] Code contains descriptive docstrings
- [ X] New/changed functions and methods are covered in the test suite where possible
- [ X] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
