### PR TITLE
CI: Dynamic Versioning for Project

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,7 @@ Benefits of decoupled architecture:
 
 import logging
 from contextlib import asynccontextmanager
+from importlib.metadata import PackageNotFoundError, version
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
@@ -24,6 +25,11 @@ from app.api.v1.router import router as v1_router
 from app.api.v1.websocket import get_diff_manager
 from app.services.epics_service import get_epics_service
 from app.services.redis_service import get_redis_service
+
+try:
+    __version__ = version("squirrel-backend")
+except PackageNotFoundError:
+    __version__ = "unknown"
 
 # Configure logging
 logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -116,7 +122,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="Squirrel Backend",
     description="High-performance EPICS snapshot/restore backend with 40k PV support",
-    version="0.2.0",
+    version=__version__,
     lifespan=lifespan,
 )
 
@@ -154,4 +160,4 @@ async def health_check():
 # Root redirect
 @app.get("/")
 async def root():
-    return {"message": "Squirrel Backend API", "docs": "/docs", "health": "/v1/health/summary", "version": "0.2.0"}
+    return {"message": "Squirrel Backend API", "docs": "/docs", "health": "/v1/health/summary", "version": __version__}

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     gcc \
     g++ \
     make \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy application

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
     gcc \
     g++ \
     make \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "squirrel-backend"
-version = "0.1.0"
+dynamic = ["version"]
 description = "High-performance EPICS snapshot/restore backend"
 requires-python = ">=3.11"
 
@@ -44,8 +44,10 @@ docs = [
 ]
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
 
 [tool.setuptools.packages.find]
 include = ["app*"]

--- a/uv.lock
+++ b/uv.lock
@@ -1857,7 +1857,6 @@ wheels = [
 
 [[package]]
 name = "squirrel-backend"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiobreaker" },


### PR DESCRIPTION
## Description
<!--- Describe individual changes -->
Dynamically version the project based off the git repository's tags. When a new release is made, the backend's version will match the GitHub release tag.

### Note***
This only works with tag names that match [PEP 0440 standards](https://peps.python.org/pep-0440/) (`#.#.#` or `v#.#.#`) as of right now, which does not include SLAC's standard `R#.#.#` tags. If we want to include those, then we need to add the line below to the `pyproject.toml` in the `[tools.setuptools_scm]` section:
```
[tool.setuptools_scm]
tag_regex = "^R(?P<version>\\d+\\.\\d+\\.\\d+)$"
```

## Motivation
<!--- Why is this change required? What problem does it solve? Do any design decisions warrant discussion? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I noticed the versions were hardcoded and wanted to change that.


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Self documenting.

## Screenshots
Tested with a dummy tag: `v1.0.5`
<img width="470" height="141" alt="Screenshot 2026-05-01 at 18 01 09" src="https://github.com/user-attachments/assets/eb550d0b-caa8-4fda-92fb-3b3e23993fc7" />

### JSON returned from `localhost:8080/`
``` json
{"message":"Squirrel Backend API","docs":"/docs","health":"/v1/health/summary","version":"1.0.5"}
```

## Pre-merge checklist

- [x] Code works interactively
- [x] Code contains descriptive docstrings
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
